### PR TITLE
Open tab grouper page on startup if tab groups exist.

### DIFF
--- a/background.js
+++ b/background.js
@@ -100,6 +100,16 @@ let messageHandler = (request, sender, sendResponse) => {
     }
 }
 
+let handleStartup = () => {
+    if (tabsStore.length > 0) {
+        chrome.tabs.create({
+            url: '/group-page/group-page.html',
+            active: true
+        }).then(tab => { groupTabId = tab.id }).catch(onError)
+    }   
+}
+
 browser.commands.onCommand.addListener(onCommandHandler)    
 browser.tabs.onUpdated.addListener(onUpdatedHandler)
 browser.runtime.onMessage.addListener(messageHandler);
+browser.runtime.onStartup.addListener(handleStartup)

--- a/group-page/group-page.html
+++ b/group-page/group-page.html
@@ -4,7 +4,7 @@
         <title>Tab Grouper</title>
         <link rel="stylesheet" href="chrome://global/skin/in-content/common.css" type="text/css" />
         <link rel="stylesheet" href="group-page.css" type="text/css" />
-        <link rel="icon" type="image/png" href="../icons/fish-32.png">
+        <link rel="icon" type="image/png" href="../icons/fish-64.png">
     </head>
     <body>
         <div class="main-content">


### PR DESCRIPTION
This is basically impossible to test with Firefox's add-on debugging, as temporary add-ons will not stay loaded between browser sessions. However, the Chrome version works, and the API methods in this instance are very similar.

Resolve #25.