### PR TITLE
Fix tab closing bug with multiple windows

### DIFF
--- a/group-page/group-page.css
+++ b/group-page/group-page.css
@@ -1,3 +1,7 @@
+body {
+    background: #2A2A2E;
+}
+
 .main-content {
     padding-left: 20px;
 }
@@ -11,7 +15,7 @@
     padding: 8px;
     margin: 8px;
     flex: 1 2 350px;
-    background-color: rgb(255, 255, 255)
+    border: 3px solid #3d7e9a;
 }
 
 .target-list {
@@ -42,7 +46,6 @@
 .close {
     width: 25px;
     height: 25px;
-    opacity: 0.5;
     cursor: pointer;
     text-align: center;
 }
@@ -53,7 +56,6 @@
     padding: 5px 5px 0 0;
     cursor: pointer;
     text-align: center;
-    opacity: 0.4;
 }
 
 .close:hover,

--- a/group-page/group-page.js
+++ b/group-page/group-page.js
@@ -67,7 +67,6 @@
 
     function renderRestoreGroupButton (element) {
         let button = document.createElement('a')
-        button.style.fontWeight = '700'
         button.style.cursor = 'pointer'
         button.text = 'Restore'
         button.title = 'Restore tab group'

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 
     "manifest_version": 2,
     "name": "Tab Grouper",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Consolidate your tabs into a list.",
     "homepage_url": "https://github.com/Zero-man/tab-grouper",
     "icons": {


### PR DESCRIPTION
Fix for #37 

There was a bug introduced where certain tab ids were ignored when closing. This fix updates some of the logic generally, and takes care of the problem.